### PR TITLE
PLAT-18 Turn node/no-unsupported-features off

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,7 @@
   "extends": [ "8select", "plugin:node/recommended" ],
   "plugins": [ "node" ],
   "rules": {
-    "node/no-unpublished-require": "off"
+    "node/no-unpublished-require": "off",
+    "node/no-unsupported-features": "off"
   }
 }


### PR DESCRIPTION
Due to babel transpiling this option is no longer required